### PR TITLE
use QRandomGenerator instead of the deprecated KRandomSequence

### DIFF
--- a/ImageData.cpp
+++ b/ImageData.cpp
@@ -26,7 +26,7 @@
 #include "ImageData.h"
 
 ImageData::ImageData() : floor_(10,10), indexSize_(0), size_(0), halfSize_(0) {
-  random.setSeed(0);
+  random.seed(0);
   QPainter paint(&floor_);
   paint.fillRect(0,0,10,10, QColor(0x66,0x66,0x66, 255));
 }
@@ -45,10 +45,10 @@ ImageData::expandIndex(int size) {
   rightSmallIndex_.resize(size);
 
   for (int i=indexSize_; i<size; i++) {
-    upperLargeIndex_[i] = random.getLong(LARGE_STONES);
-    lowerLargeIndex_[i] = random.getLong(LARGE_STONES);
-    leftSmallIndex_[i] = random.getLong(SMALL_STONES);
-    rightSmallIndex_[i] = random.getLong(SMALL_STONES);
+    upperLargeIndex_[i] = random.bounded(LARGE_STONES);
+    lowerLargeIndex_[i] = random.bounded(LARGE_STONES);
+    leftSmallIndex_[i] = random.bounded(SMALL_STONES);
+    rightSmallIndex_[i] = random.bounded(SMALL_STONES);
   }
 
   indexSize_ = size;

--- a/ImageData.h
+++ b/ImageData.h
@@ -23,7 +23,7 @@
 #include <QImage>
 #include <QPixmap>
 
-#include <KRandomSequence>
+#include <QRandomGenerator>
 
 class QPainter;
 
@@ -81,7 +81,7 @@ protected:
   QByteArray rightSmallIndex_;
 
   int size_, halfSize_;
-  KRandomSequence random;
+  QRandomGenerator random;
 };
 
 #endif  /* IMAGEDATA_H */


### PR DESCRIPTION
This was to fix the following compilation issue on kde
framework 5.75.0:

ImageData.h:84:3: error: 'KRandomSequence' does not name a type
   84 |   KRandomSequence random;
      |   ^~~~~~~~~~~~~~~

Signed-off-by: Joshua Houghton <joshua.houghton@yandex.ru>